### PR TITLE
Update to jobqueue 0.4.0

### DIFF
--- a/server-side/.gitignore
+++ b/server-side/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints
+dask-worker*

--- a/server-side/Reading LENS example.ipynb
+++ b/server-side/Reading LENS example.ipynb
@@ -26,7 +26,7 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3>Client</h3>\n",
        "<ul>\n",
-       "  <li><b>Scheduler: </b>tcp://10.148.10.13:36098\n",
+       "  <li><b>Scheduler: </b>tcp://10.148.10.13:38822\n",
        "  <li><b>Dashboard: </b><a href='http://localhost:8888/proxy/8787/status' target='_blank'>http://localhost:8888/proxy/8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
@@ -42,7 +42,7 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://10.148.10.13:36098' processes=0 cores=0>"
+       "<Client: scheduler='tcp://10.148.10.13:38822' processes=0 cores=0>"
       ]
      },
      "execution_count": 1,
@@ -74,7 +74,7 @@
    "source": [
     "### Launch workers\n",
     "\n",
-    "Each worker is a compute node (with 36 cores). If you request `N` workers, then `N` single-node jobs will be submitted to the queue; work will be spread among available workers."
+    "Each worker is a process, and jobqueue.yaml is specifying a process as 4 cores (1/9 of a node). Therefore, if you request `9*N` workers, then `N` single-node jobs will be submitted to the queue; work will be spread among available workers."
    ]
   },
   {
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster.scale(5)"
+    "cluster.scale(9*5)"
    ]
   },
   {
@@ -148,14 +148,14 @@
       "      dtype=float32)\n",
       "Coordinates:\n",
       "    time     float64 6.753e+05\n",
-      "    ULAT     (nlat, nlon) float64 -78.95 -78.95 -78.95 -78.95 -78.95 -78.95 ...\n",
-      "    ULONG    (nlat, nlon) float64 321.1 322.3 323.4 324.5 325.6 326.8 327.9 ...\n",
+      "    ULAT     (nlat, nlon) float64 -78.95 -78.95 -78.95 ... 72.42 72.41 72.41\n",
+      "    ULONG    (nlat, nlon) float64 321.1 322.3 323.4 324.5 ... 319.2 319.6 320.0\n",
       "    z_t      float32 500.0\n",
       "    TLAT     (nlat, nlon) float64 dask.array<shape=(384, 320), chunksize=(384, 320)>\n",
       "    TLONG    (nlat, nlon) float64 dask.array<shape=(384, 320), chunksize=(384, 320)>\n",
       "Dimensions without coordinates: nlat, nlon\n",
-      "CPU times: user 2.02 s, sys: 76 ms, total: 2.1 s\n",
-      "Wall time: 8.37 s\n"
+      "CPU times: user 3.71 s, sys: 104 ms, total: 3.82 s\n",
+      "Wall time: 8.68 s\n"
      ]
     }
    ],
@@ -183,8 +183,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.3 s, sys: 4.02 s, total: 6.33 s\n",
-      "Wall time: 3.52 s\n"
+      "CPU times: user 2.84 s, sys: 4.02 s, total: 6.86 s\n",
+      "Wall time: 3.08 s\n"
      ]
     },
     {
@@ -194,7 +194,9 @@
        "<Figure size 648x360 with 2 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],

--- a/server-side/Reading LENS example.ipynb
+++ b/server-side/Reading LENS example.ipynb
@@ -26,7 +26,7 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3>Client</h3>\n",
        "<ul>\n",
-       "  <li><b>Scheduler: </b>tcp://10.148.10.13:38822\n",
+       "  <li><b>Scheduler: </b>tcp://10.148.10.13:41487\n",
        "  <li><b>Dashboard: </b><a href='http://localhost:8888/proxy/8787/status' target='_blank'>http://localhost:8888/proxy/8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
@@ -42,7 +42,7 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://10.148.10.13:38822' processes=0 cores=0>"
+       "<Client: scheduler='tcp://10.148.10.13:41487' processes=0 cores=0>"
       ]
      },
      "execution_count": 1,
@@ -154,8 +154,8 @@
       "    TLAT     (nlat, nlon) float64 dask.array<shape=(384, 320), chunksize=(384, 320)>\n",
       "    TLONG    (nlat, nlon) float64 dask.array<shape=(384, 320), chunksize=(384, 320)>\n",
       "Dimensions without coordinates: nlat, nlon\n",
-      "CPU times: user 3.71 s, sys: 104 ms, total: 3.82 s\n",
-      "Wall time: 8.68 s\n"
+      "CPU times: user 1.78 s, sys: 132 ms, total: 1.92 s\n",
+      "Wall time: 8.45 s\n"
      ]
     }
    ],
@@ -183,8 +183,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.84 s, sys: 4.02 s, total: 6.86 s\n",
-      "Wall time: 3.08 s\n"
+      "CPU times: user 1.73 s, sys: 1.96 s, total: 3.7 s\n",
+      "Wall time: 2.67 s\n"
      ]
     },
     {
@@ -225,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/server-side/Reading LENS example.ipynb
+++ b/server-side/Reading LENS example.ipynb
@@ -26,8 +26,8 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3>Client</h3>\n",
        "<ul>\n",
-       "  <li><b>Scheduler: </b>tcp://10.148.7.225:35489\n",
-       "  <li><b>Dashboard: </b><a href='http://localhost:8787/status' target='_blank'>http://localhost:8787/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.148.10.13:36098\n",
+       "  <li><b>Dashboard: </b><a href='http://localhost:8888/proxy/8787/status' target='_blank'>http://localhost:8888/proxy/8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
@@ -42,7 +42,7 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://10.148.7.225:35489' processes=0 cores=0>"
+       "<Client: scheduler='tcp://10.148.10.13:36098' processes=0 cores=0>"
       ]
      },
      "execution_count": 1,
@@ -57,20 +57,8 @@
     "\n",
     "from dask.distributed import Client\n",
     "from dask_jobqueue import PBSCluster\n",
-    "# Note dashboard link (relying on nbserverproxy) doesn't work right with\n",
-    "# dask-jobqueue v0.3.0; running\n",
-    "# $ conda uninstall dask-jobqueue\n",
-    "# $ pip install git+https://github.com/dask/dask-jobqueue\n",
-    "# to get dask-jobqueue-0.3.0+31.g4ea3c98 (or later)\n",
-    "# makes the dashboard link work but then cluster.scale() doesn't seem to submit any jobs?\n",
-    "# We should probably wait for next dask-jobqueue release\n",
     "\n",
     "# Lots of arguments to this command are set in ~/.config/dask/jobqueue.yaml\n",
-    "# Also note that jobqueue.yaml renders\n",
-    "#dask.config.set({'distributed.dashboard.link':'http://localhost:8888/proxy/{port}/status'})\n",
-    "dask.config.set({'distributed.dashboard.link':'http://localhost:{port}/status'})\n",
-    "# Obsolete... I think we want to recommend that for all cheyenne users along with nbserverproxy\n",
-    "\n",
     "# I intentionally did not put a project number in jobqueue.yaml to make it easier to share\n",
     "# Default queue is regular, but I am using premium because I am impatient\n",
     "# Default walltime is 30 minutes\n",
@@ -235,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/server-side/jobqueue.yaml
+++ b/server-side/jobqueue.yaml
@@ -4,25 +4,26 @@ jobqueue:
 
     # Dask worker options
     cores: 36                 # Total number of cores per job
-    memory: "100 GB"                # Total amount of memory per job
-    processes: 9                # Number of Python processes per job
+    memory: '109 GB'          # Total amount of memory per job
+    processes: 9              # Number of Python processes per job
 
-    interface: ib0              # Network interface to use like eth0 or ib0
-    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
-    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+    interface: ib0            # Network interface to use like eth0 or ib0
+    death-timeout: 60         # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null     # Location of fast local storage like /scratch or $TMPDIR
 
     # PBS resource manager options
     queue: regular
     # project: YOUR PROJECT KEY HERE
     walltime: '00:30:00'
+    resource-spec: select=1:ncpus=36:mem=109GB
 
 distributed:
   dashboard:
     link: http://localhost:8888/proxy/{port}/status
   worker:
     memory:
-      target: false  # don't spill to disk
-      spill: false  # don't spill to disk
-      pause: 0.80  # pause execution at 80% memory use
-      terminate: 0.95  # restart the worker at 95% use
+      target: false           # don't spill to disk
+      spill: false            # don't spill to disk
+      pause: 0.80             # pause execution at 80% memory use
+      terminate: 0.95         # restart the worker at 95% use
 

--- a/server-side/pangeo-cheyenne.yaml
+++ b/server-side/pangeo-cheyenne.yaml
@@ -6,9 +6,14 @@ channels:
 dependencies:
   - python=3
   - dask
+# To ensure our example notebook is consistent with jobqueue API, we
+# specify a version to use
   - dask-jobqueue=0.4.0
+  - numpy
   - xarray
   - jupyterlab
-  - matplotlib
+# matplotlib 3.0.0 doesn't work with Cartopy, so specify 2.2.3
+# see https://github.com/SciTools/cartopy/issues/1120 for details
+  - matplotlib=2.2.3
   - Cartopy
   - nbserverproxy

--- a/server-side/pangeo-cheyenne.yaml
+++ b/server-side/pangeo-cheyenne.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3
   - dask
-  - dask-jobqueue=0.3.0
+  - dask-jobqueue=0.4.0
   - xarray
   - jupyterlab
   - matplotlib

--- a/server-side/pangeo-cheyenne.yaml
+++ b/server-side/pangeo-cheyenne.yaml
@@ -12,10 +12,10 @@ dependencies:
   - numpy
   - xarray
   - jupyterlab
-# matplotlib 3.0.0 doesn't work with Cartopy, so specify 2.2.3
+# matplotlib 3.0.0 doesn't work with Cartopy 0.16.0, so specify 2.2.3
 # see https://github.com/SciTools/cartopy/issues/1120 for details
   - matplotlib=2.2.3
-  - Cartopy
+  - Cartopy=0.16.0
 # Bug in nbserverproxy 0.8.3 or tornado 5.1.1 causing blank dashboard
 # Older version of tornado seems to still work
   - tornado=5.0.2

--- a/server-side/pangeo-cheyenne.yaml
+++ b/server-side/pangeo-cheyenne.yaml
@@ -16,4 +16,7 @@ dependencies:
 # see https://github.com/SciTools/cartopy/issues/1120 for details
   - matplotlib=2.2.3
   - Cartopy
-  - nbserverproxy
+# Bug in nbserverproxy 0.8.3 or tornado 5.1.1 causing blank dashboard
+# Older version of tornado seems to still work
+  - tornado=5.0.2
+  - nbserverproxy=0.8.3


### PR DESCRIPTION
This PR enables cheyenne users to rely on nbserverproxy to view the dask dashboard rather than needing to tunnel through the dashboard port.

Not sure who is the best person to review this before I merge it, so I selected a few people... no pressure, if you don't want to look this over I understand. (If no one wants to look it over, I'll test it myself one more time and then merge it.)